### PR TITLE
Add files via upload

### DIFF
--- a/.themes/Aquarium/aquarium_day.conf
+++ b/.themes/Aquarium/aquarium_day.conf
@@ -1,0 +1,37 @@
+foreground            #202EDa
+background            #ddeeff
+selection_foreground  #c8cedc
+selection_background  #414560
+url_color             #9d8567
+
+# black
+color0   #313449
+color8   #414560
+
+# red
+color1   #c82828
+color9   #bf2828
+
+# green
+color2   #709760
+color10  #32a852
+
+# yellow
+color3   #e9b600
+color11  #bdbf28
+
+# blue
+color4   #4170ae
+color12  #3228bf
+
+# magenta
+color5   #8958a7
+color13  #bf28bc
+
+# cyan
+color6   #3d999f
+color14  #28bfba
+
+# white
+color7   #abb2c2
+color15  #e7e7e7


### PR DESCRIPTION
Aquarium Day mode, trying to keep the theme of normal Aquarium with blue background and vibrant foreground colors. Colors 1-7 taken from Tomorrow theme, 8-15 chosen by me to be clear highlight colors.

I'm pretty happy with all foreground colors, but the background still needs tuning. Currently at #DDEEFF, any dimmer and I feel it becomes difficult to see in a fully naturally lit environment.